### PR TITLE
fix: Language server not executable

### DIFF
--- a/copilot/index.js
+++ b/copilot/index.js
@@ -1,4 +1,4 @@
-#!/bin/node
+#!/usr/bin/env node
 
 global.__rootDirectory = __dirname + '/dist/';
 


### PR DESCRIPTION
`#!/bin/node` is reliant on `node` being installed in`/bin`

MacOS doesn't have `node` at that location (at least not for me). `#!/usr/bin/env node` uses the `node` set in `PATH`, so  this should work for all Linux/macOS environments.

Thanks for making this repo, and I hope it's not weird that I made this PR! 😅
