### PR TITLE
Fixed the vim-pack incompatability and improved configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 This plugin is the pure lua replacement for https://github.com/github/copilot.vim
 
-While using copilot.vim, for the first time since I started using neovim my laptop began to overheat. Additionally, I found the large chunks of ghost text moving around my code, and interfering with my existing cmp ghost text disturbing. As lua is far more efficient and makes things easier to integrate with modern plugins, this repository was created. 
+While using copilot.vim, for the first time since I started using neovim my laptop began to overheat. Additionally, I found the large chunks of ghost text moving around my code, and interfering with my existing cmp ghost text disturbing. As lua is far more efficient and makes things easier to integrate with modern plugins, this repository was created.
 
 ## (IMPORTANT) Usage:
+
 Note that this plugin will only start up the copilot server. The current usage of this is via https://github.com/zbirenbaum/copilot-cmp, which turns copilot suggestions into menu entries for cmp, and displays the full text body in a float, similar to how documentation would appear, off to the side.
 
 On its own, this plugin will do nothing. You must either use https://github.com/zbirenbaum/copilot-cmp to make the server into a cmp source, or write your own plugin to interface with it, via the request and handler methods located in copilot.utils.lua
@@ -12,33 +13,49 @@ On its own, this plugin will do nothing. You must either use https://github.com/
 ## Install
 
 ### Preliminary Steps
+
 Currently, you must have had the original copilot.vim installed and set up at some point, as the authentication steps you do during its setup create files in ~/.config/github-copilot which copilot.lua must read from to function. Fairly soon, copilot.lua will be able to perform this authentication step on its own, but as the plugin is in early stages, this has not yet been fully implemented.
 
-Install copilot.vim with `use {"github/copilot.vim"}`, `:PackerSync`, restart, and run `:Copilot` to be prompted for the necessary setup steps. 
+Install copilot.vim with `use {"github/copilot.vim"}`, `:PackerSync`, restart, and run `:Copilot` to be prompted for the necessary setup steps.
 
 After the setup steps are complete for copilot.vim, ensure that ~/.config/github-copilot has files in it, and then you are free to uninstall copilot.vim and proceed to the following steps.
 
 ### Setup
+
+You have to run the `require("copilot").setup(options)` function in order to start Copilot. If no options are provided, the defaults are used.
+
 Because the copilot server takes some time to start up, I HIGHLY recommend that you load copilot after startup. This can be done in multiple ways:
+
 1. On 'InsertEnter': (My preferred way)
+
 ```
 use {
   "zbirenbaum/copilot.lua",
   event = "InsertEnter",
   config = function ()
-    vim.schedule(function() require("copilot") end)
+    vim.schedule(function() require("copilot").setup() end)
   end,
 },
 ```
+
 2. Load After Statusline + defer:
+
 ```
 ["zbirenbaum/copilot.lua"] = {
   "zbirenbaum/copilot.lua",
   after = 'feline.nvim', --whichever statusline plugin you use here
   config = function ()
-    vim.defer_fn(function() require("copilot") end, 100)
+    vim.defer_fn(function() require("copilot").setup() end, 100)
   end,
 },
 ```
 
+#### Configuration
 
+The following is the default configuration:
+
+```lua
+{
+	plugin_manager_path = vim.fn.stdpath("data") .. "/site/pack/packer", -- Installation Path of packer, change to the plugin manager installation path of your choice
+}
+```

--- a/lua/copilot/config.lua
+++ b/lua/copilot/config.lua
@@ -1,0 +1,19 @@
+local M = {}
+
+local defaults = {
+	plugin_manager_path = vim.fn.stdpath("data") .. "/site/pack/packer",
+}
+
+M.params = {}
+
+M.setup = function(options)
+	if not options then
+		M.params = defaults
+	else
+		for key, value in pairs(defaults) do
+			M.params[key] = options[key] or value
+		end
+	end
+end
+
+return M

--- a/lua/copilot/init.lua
+++ b/lua/copilot/init.lua
@@ -1,1 +1,11 @@
-require("copilot.copilot_handler").start()
+local config = require("copilot.config")
+local M = {}
+
+M.setup = function (params)
+    config.setup(params)
+    config.params.plugin_manager_path = vim.fn.expand(config.params.plugin_manager_path) -- resolve wildcard and variable containing paths
+    require("copilot.copilot_handler").start(config.params.plugin_manager_path)
+end
+
+
+return M

--- a/lua/copilot/util.lua
+++ b/lua/copilot/util.lua
@@ -28,10 +28,8 @@ M.get_completion_params = function()
 end
 
 M.get_copilot_path = function(plugin_path)
-   local root_path = plugin_path or vim.fn.stdpath("data")
-   local packer_path =  root_path .. "/site/pack/packer/"
-   for _, loc in ipairs{"opt", "start"} do
-      local copilot_path = packer_path .. loc .. "/copilot.lua/copilot/index.js"
+   for _, loc in ipairs{"/opt", "/start", ""} do
+      local copilot_path = plugin_path .. loc .. "/copilot.lua/copilot/index.js"
       if vim.fn.filereadable(copilot_path) ~= 0 then
          return copilot_path
       end


### PR DESCRIPTION
Hi, 
first of all, great work. This plugin was released exactly as I got my Copilot access and fits so much better into my workflow than the official alternative. So thank you.

The problem is, it doesn't work with my setup, since you assume Packer as package management solution, which I don't use yet. To make this plugin package manager or rather installation path agnostic, I changed the way the Copilot path finding works and while I was at it, I made the whole plugin more extendable and idiomatic to current NeoVim Plugin conventions by introduction a `setup` function for easy customization.

Most modern nvim plugins have such a function to, as the name suggests, setup the plugin's functionality.
e.g. [Telescope](https://github.com/nvim-telescope/telescope.nvim/blob/master/lua/telescope/init.lua#L77) or [Trouble](https://github.com/folke/trouble.nvim/blob/main/lua/trouble/init.lua#L16)

I also changed the README to suit the proposed changes

Kind regards, Daniel

P.S. Keep up the good work :)