### PR TITLE
remove pack_manager_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ panel = { -- no config options yet
   enabled = true,
 },
 ft_disable = {},
-plugin_manager_path = vim.fn.stdpath("data") .. "/site/pack/packer",
 server_opts_overrides = {},
 ```
 
@@ -113,18 +112,6 @@ Example:
 ```lua
 require("copilot").setup {
   ft_disable = { "markdown", "terraform" },
-}
-```
-
-##### plugin_manager_path
-
-This is installation path of Packer, change this to the plugin manager installation path of your choice
-
-Example:
-
-```lua
-require("copilot").setup {
-  plugin_manager_path = vim.fn.stdpath("data") .. "/site/pack/packer", 
 }
 ```
 

--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -19,7 +19,7 @@ end
 
 M.merge_server_opts = function (params)
   return vim.tbl_deep_extend("force", {
-    cmd = { "node", require("copilot.util").get_copilot_path(params.plugin_manager_path) },
+    cmd = { "node", require("copilot.util").get_copilot_path() },
     name = "copilot",
     root_dir = vim.loop.cwd(),
     autostart = true,

--- a/lua/copilot/init.lua
+++ b/lua/copilot/init.lua
@@ -10,7 +10,6 @@ local defaults = {
     enabled = true,
   },
   ft_disable = {},
-  plugin_manager_path = vim.fn.stdpath("data") .. "/site/pack/packer",
   server_opts_overrides = {},
 }
 

--- a/lua/copilot/util.lua
+++ b/lua/copilot/util.lua
@@ -39,14 +39,9 @@ M.get_completion_params = function()
   return params
 end
 
-M.get_copilot_path = function(plugin_path)
-  for _, loc in ipairs({ "/opt", "/start", "" }) do
-    local copilot_path = plugin_path .. loc .. "/copilot.lua/copilot/index.js"
-    if vim.fn.filereadable(copilot_path) ~= 0 then
-      return copilot_path
-    end
-  end
+M.get_copilot_path = function()
+  local plugin_path = vim.api.nvim_exec("echo expand('<sfile>:p:h:h:h')", true)
+  return plugin_path .. "/copilot/index.js"
 end
-
 
 return M


### PR DESCRIPTION
We can get the plugin directory directly instead of searching from the pack manager path. This can make the life of users that don't use packer a bit easier.

See https://neovim.discourse.group/t/get-path-to-plugin-directory/2658