### PR TITLE
Fix attaching to buffer on Neovim < 0.8

### DIFF
--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -10,10 +10,13 @@ M.buf_attach_copilot = function()
   if vim.tbl_contains(M.params.ft_disable, vim.bo.filetype) then return end
   if not vim.bo.buflisted or not vim.bo.buftype == "" then return end
   local name = M.params.server_opts_overrides.name or "copilot"
-  local client = vim.lsp.get_active_clients({name=name})[1]
-  if client and not vim.lsp.buf_is_attached(0, client.id) then
-    vim.lsp.buf_attach_client(0, client.id)
-    client.completion_function = M.params.extensions
+  
+  -- The filter param to get_active_clients() can be used on Neovim 0.8 and later.
+  for _, client in pairs(vim.lsp.get_active_clients()) do
+    if client.name == name and not vim.lsp.buf_is_attached(0, client.id) then
+      vim.lsp.buf_attach_client(0, client.id)
+      client.completion_function = M.params.extensions
+    end
   end
 end
 


### PR DESCRIPTION
The `filter` option to `vim.lsp.get_active_clients()` is not available in 0.7 and earlier.