### PR TITLE
feat: add copilot.api module

### DIFF
--- a/lua/copilot/api.lua
+++ b/lua/copilot/api.lua
@@ -1,0 +1,187 @@
+local mod = {}
+
+---@param callback? fun(err: any|nil, data: table, ctx: table): nil
+---@return any|nil err
+---@return table data
+---@return table ctx
+function mod.request(client, method, params, callback)
+  -- hack to convert empty table to json object,
+  -- empty table is convert to json array by default.
+  params._ = true
+
+  local bufnr = params.bufnr
+  params.bufnr = nil
+
+  if callback then
+    return client.request(method, params, callback, bufnr)
+  end
+
+  local co = coroutine.running()
+  client.request(method, params, function(err, data, ctx)
+    coroutine.resume(co, err, data, ctx)
+  end, bufnr)
+  return coroutine.yield()
+end
+
+---@return boolean sent
+function mod.notify(client, method, params)
+  return client.notify(method, params)
+end
+
+---@alias copilot_check_status_data { user?: string }
+
+---@return any|nil err
+---@return copilot_check_status_data data
+---@return table ctx
+function mod.check_status(client, callback)
+  return mod.request(client, "checkStatus", {}, callback)
+end
+
+---@alias copilot_sign_in_initiate_data { verificationUri?: string, userCode?: string }
+
+---@return any|nil err
+---@return copilot_sign_in_initiate_data data
+---@return table ctx
+function mod.sign_in_initiate(client, callback)
+  return mod.request(client, "signInInitiate", {}, callback)
+end
+
+---@alias copilot_sign_in_confirm_params { userId: string }
+---@alias copilot_sign_in_confirm_data { status: string, error: { message: string }, user: string }
+
+---@param params copilot_sign_in_confirm_params
+---@return any|nil err
+---@return copilot_sign_in_confirm_data data
+---@return table ctx
+function mod.sign_in_confirm(client, params, callback)
+  return mod.request(client, "signInConfirm", params, callback)
+end
+
+---@alias copilot_notify_accepted_params { uuid: string }
+
+---@param params copilot_notify_accepted_params
+function mod.notify_accepted(client, params, callback)
+  return mod.request(client, "notifyAccepted", params, callback)
+end
+
+---@alias copilot_notify_rejected_params { uuids: string[] }
+
+---@param params copilot_notify_rejected_params
+function mod.notify_rejected(client, params, callback)
+  return mod.request(client, "notifyRejected", params, callback)
+end
+
+---@alias copilot_notify_shown_params { uuid: string }
+
+---@param params copilot_notify_shown_params
+function mod.notify_shown(client, params, callback)
+  return mod.request(client, "notifyShown", params, callback)
+end
+
+---@alias copilot_get_completions_data { completions: { displayText: string, position: { character: integer, line: integer }, range: { ['end']: { character: integer, line: integer }, start: { character: integer, line: integer } }, text: string, uuid: string }[] }
+
+---@return any|nil err
+---@return copilot_get_completions_data data
+---@return table ctx
+function mod.get_completions(client, params, callback)
+  return mod.request(client, "getCompletions", params, callback)
+end
+
+function mod.get_completions_cycling(client, params, callback)
+  return mod.request(client, "getCompletionsCycling", params, callback)
+end
+
+---@alias copilot_get_panel_completions_data { solutionCountTarget: integer }
+---@alias copilot_panel_solution_data { panelId: string, completionText: string, displayText: string, range: { ['end']: { character: integer, line: integer }, start: { character: integer, line: integer } }, score: number, solutionId: string }
+---@alias copilot_panel_on_solution_handler fun(result: copilot_panel_solution_data): nil
+---@alias copilot_panel_solutions_done_data { panelId: string, status: 'OK'|'Error', message?: string }
+---@alias copilot_panel_on_solutions_done_handler fun(result: copilot_panel_solutions_done_data): nil
+
+---@return any|nil err
+---@return copilot_get_panel_completions_data data
+---@return table ctx
+function mod.get_panel_completions(client, params, callback)
+  return mod.request(client, "getPanelCompletions", params, callback)
+end
+
+local panel = {
+  callback = {
+    PanelSolution = {},
+    PanelSolutionsDone = {},
+  },
+}
+
+panel.handlers = {
+  ---@param result copilot_panel_solution_data
+  PanelSolution = function(_, result)
+    if panel.callback.PanelSolution[result.panelId] then
+      panel.callback.PanelSolution[result.panelId](result)
+    end
+  end,
+
+  ---@param result copilot_panel_solutions_done_data
+  PanelSolutionsDone = function(_, result)
+    if panel.callback.PanelSolutionsDone[result.panelId] then
+      panel.callback.PanelSolutionsDone[result.panelId](result)
+    end
+  end,
+}
+
+---@param panelId string
+---@param handlers { on_solution: copilot_panel_on_solution_handler, on_solutions_done: copilot_panel_on_solutions_done_handler }
+function mod.register_panel_handlers(panelId, handlers)
+  assert(type(panelId) == "string", "missing panelId")
+  panel.callback.PanelSolution[panelId] = handlers.on_solution
+  panel.callback.PanelSolutionsDone[panelId] = handlers.on_solutions_done
+end
+
+---@param panelId string
+function mod.unregister_panel_handlers(panelId)
+  assert(type(panelId) == "string", "missing panelId")
+  panel.callback.PanelSolution[panelId] = nil
+  panel.callback.PanelSolutionsDone[panelId] = nil
+end
+
+---@alias copilot_status_notification_data { status: string, message: string }
+
+local status = {
+  client_id = nil,
+  data = {
+    status = "",
+    message = "",
+  },
+  callback = {},
+}
+
+status.handlers = {
+  ---@param result copilot_status_notification_data
+  ---@param ctx { client_id: integer, method: string }
+  statusNotification = function(_, result, ctx)
+    status.client_id = ctx.client_id
+    status.data = result
+
+    for callback in pairs(status.callback) do
+      callback(status.data)
+    end
+  end,
+}
+
+---@param handler fun(data: copilot_status_notification_data): nil
+function mod.register_status_notification_handler(handler)
+  status.callback[handler] = true
+end
+
+---@param handler fun(data: copilot_status_notification_data): nil
+function mod.unregister_status_notification_handler(handler)
+  status.callback[handler] = nil
+end
+
+mod.handlers = {
+  PanelSolution = panel.handlers.PanelSolution,
+  PanelSolutionsDone = panel.handlers.PanelSolutionsDone,
+  statusNotification = status.handlers.statusNotification,
+}
+mod.panel = panel
+mod.status = status
+
+return mod

--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -1,5 +1,7 @@
-local M = { params = {} }
+local api = require("copilot.api")
 local util = require("copilot.util")
+
+local M = { params = {} }
 
 local register_autocmd = function ()
   vim.api.nvim_create_autocmd({ "BufEnter" }, {
@@ -36,6 +38,11 @@ M.merge_server_opts = function (params)
       vim.schedule(M.buf_attach_copilot)
       vim.schedule(register_autocmd)
     end,
+    handlers = {
+      -- PanelSolution = api.handlers.PanelSolution,
+      -- PanelSolutionsDone = api.handlers.PanelSolutionsDone,
+      statusNotification = api.handlers.statusNotification,
+    }
   }, params.server_opts_overrides or {})
 end
 


### PR DESCRIPTION
## Description

- util changes to follow the `copilot.vim` behavior closely
- ~panel changes to make it more extensible~
- `copilot.api` module can be used by any plugins that want to implement UI for `copilot.lua`

## Using the `copilot.api` module

The APIs can be used in two flavors:

**Callback**

```lua
local sent, request_id = require("copilot.api").check_status(client, function(err, data, ctx)
  print(vim.inspect({ err = err, data = data, ctx = ctx })
end)
```

**Coroutine**

```lua
coroutine.wrap(function()
  local err, data, ctx = require("copilot.api").check_status(client)
  print(vim.inspect({ err = err, data = data, ctx = ctx })
end)()
```

---

I'll be creating followup PRs to make the panel fully functional.