### PR TITLE
feat: support 'filetypes' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,17 @@ suggestion = {
    dismiss = "<C-]>",
   },
 },
-ft_disable = {},
+filetypes = {
+  yaml = false,
+  markdown = false,
+  help = false,
+  gitcommit = false,
+  gitrebase = false,
+  hgcommit = false,
+  svn = false,
+  cvs = false,
+  ["."] = false,
+},
 copilot_node_command = 'node', -- Node version must be < 18
 plugin_manager_path = vim.fn.stdpath("data") .. "/site/pack/packer",
 server_opts_overrides = {},
@@ -95,7 +105,7 @@ require("copilot").setup {
 
 ```
 
-#### suggestion
+##### suggestion
 
 When `auto_trigger` is `true`, copilot starts suggesting as soon as you enter insert mode. 
 
@@ -118,15 +128,30 @@ end)
 ```
 
 
-##### ft_disable
+##### filetypes
 
-Prevents copilot from attaching to buffers with specific filetypes.
+Specify filetypes for attaching copilot.
 
 Example:
 
 ```lua
 require("copilot").setup {
-  ft_disable = { "markdown", "terraform" },
+  filetypes = {
+    markdown = true, -- overrides default
+    terraform = false, -- disallow specific filetype
+  },
+}
+```
+
+If you add `"*"` as a filetype, the default configuration for `filetypes` won't be used anymore. e.g.
+
+```lua
+require("copilot").setup {
+  filetypes = {
+    javascript = true, -- allow specific filetype
+    typescript = true, -- allow specific filetype
+    ["*"] = false, -- disable for all other filetypes and ignore default `filetypes`
+  },
 }
 ```
 

--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -9,8 +9,50 @@ local register_autocmd = function ()
   })
 end
 
+local default_filetypes = {
+  yaml = false,
+  markdown = false,
+  help = false,
+  gitcommit = false,
+  gitrebase = false,
+  hgcommit = false,
+  svn = false,
+  cvs = false,
+  ["."] = false,
+}
+
+local function is_ft_disabled(ft)
+  --- for backward compatibility
+  if M.params.ft_disable and vim.tbl_contains(M.params.ft_disable, ft) then
+    return true
+  end
+
+  if M.params.filetypes[ft] ~= nil then
+    return not M.params.filetypes[ft]
+  end
+
+  local short_ft = string.gsub(ft, "%..*", "")
+
+  if M.params.filetypes[short_ft] ~= nil then
+    return not M.params.filetypes[short_ft]
+  end
+
+  if M.params.filetypes['*'] ~= nil then
+    return not M.params.filetypes['*']
+  end
+
+  if default_filetypes[short_ft] ~= nil then
+    return not default_filetypes[short_ft]
+  end
+
+  return false
+end
+
 M.buf_attach_copilot = function()
-  if vim.tbl_contains(M.params.ft_disable, vim.bo.filetype) then return end
+  if is_ft_disabled(vim.bo.filetype) then
+    return
+  end
+
   if not vim.bo.buflisted or not vim.bo.buftype == "" then return end
   -- The filter param to get_active_clients() can be used on Neovim 0.8 and later.
   for _, client in pairs(vim.lsp.get_active_clients()) do

--- a/lua/copilot/init.lua
+++ b/lua/copilot/init.lua
@@ -17,7 +17,8 @@ local defaults = {
       dismiss = "<C-]>",
     }
   },
-  ft_disable = {},
+  ft_disable = nil,
+  filetypes = {},
   copilot_node_command = "node",
   plugin_manager_path = vim.fn.stdpath("data") .. "/site/pack/packer",
   server_opts_overrides = {},


### PR DESCRIPTION
Resolves #51

Specify filetypes for attaching copilot.

Default (same as `copilot.vim`):

```lua
filetypes = {
  yaml = false,
  markdown = false,
  help = false,
  gitcommit = false,
  gitrebase = false,
  hgcommit = false,
  svn = false,
  cvs = false,
  ["."] = false, -- usually include secrets (e.g. dotfiles, .env* files)
},
```


Example:

```lua
require("copilot").setup {
  filetypes = {
    markdown = true, -- overrides default
    terraform = false, -- disallow specific filetype
  },
}
```

If you add `"*"` as a filetype, the default configuration for `filetypes` won't be used anymore. e.g.

```lua
require("copilot").setup {
  filetypes = {
    javascript = true, -- allow specific filetype
    typescript = true, -- allow specific filetype
    ["*"] = false, -- disable for all other filetypes and ignore default `filetypes`
  },
}
```
