### PR TITLE
feat(suggestion): support partial accept

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,12 @@ require('copilot').setup({
     auto_trigger = false,
     debounce = 75,
     keymap = {
-     accept = "<M-l>",
-     next = "<M-]>",
-     prev = "<M-[>",
-     dismiss = "<C-]>",
+      accept = "<M-l>",
+      accept_word = false,
+      accept_line = false,
+      next = "<M-]>",
+      prev = "<M-[>",
+      dismiss = "<C-]>",
     },
   },
   filetypes = {

--- a/lua/copilot/config.lua
+++ b/lua/copilot/config.lua
@@ -21,6 +21,8 @@ local default_config = {
     ---@type table<'accept'|'next'|'prev'|'dismiss', false|string>
     keymap = {
       accept = "<M-l>",
+      accept_word = false,
+      accept_line = false,
       next = "<M-]>",
       prev = "<M-[>",
       dismiss = "<C-]>",

--- a/plugin/copilot.lua
+++ b/plugin/copilot.lua
@@ -2,7 +2,7 @@ local completion_store = {
   [""] = { "auth", "panel", "suggestion", "status", "toggle", "version" },
   auth = { "signin", "signout" },
   panel = { "accept", "jump_next", "jump_prev", "open", "refresh" },
-  suggestion = { "accept", "dismiss", "next", "prev", "toggle_auto_trigger" },
+  suggestion = { "accept", "accept_word", "accept_line", "dismiss", "next", "prev", "toggle_auto_trigger" },
 }
 
 vim.api.nvim_create_user_command("Copilot", function(opts)


### PR DESCRIPTION
Resolves https://github.com/zbirenbaum/copilot.lua/issues/85

```lua
require("copilot").setup({
  suggestion = {
    keymap = {
      accept_word = "<M-Right>",
      accept_line = "<M-Down>",
    },
  },
})
```