### PR TITLE
Add panel ui options

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ require('copilot').setup({
       refresh = "gr",
       open = "<M-CR>"
     },
+    layout = {
+      position = "bottom", -- bottom | top | left | right
+      ratio = 0.4
+    },
   },
   suggestion = {
     enabled = true,
@@ -99,7 +103,7 @@ The `copilot.panel` module exposes the following functions:
 require("copilot.panel").accept()
 require("copilot.panel").jump_next()
 require("copilot.panel").jump_prev()
-require("copilot.panel").open()
+require("copilot.panel").open({postion, ratio})
 require("copilot.panel").refresh()
 ```
 

--- a/lua/copilot/config.lua
+++ b/lua/copilot/config.lua
@@ -12,6 +12,10 @@ local default_config = {
       refresh = "gr",
       open = "<M-CR>",
     },
+    layout = {
+      position = "bottom",
+      ratio = 0.4
+    }
   },
   ---@class copilot_config_suggestion
   suggestion = {


### PR DESCRIPTION
Add config options for default panel split and size behavior. Adds optional table parameter to `panel.open` where these options can be overriden for use in keymaps.

Implements zbirenbaum/copilot.lua#103
