### PR TITLE
feat(panel): add close keymap to panel

### DIFF
--- a/lua/copilot/panel.lua
+++ b/lua/copilot/panel.lua
@@ -283,6 +283,14 @@ local function set_keymap(bufnr)
       silent = true,
     })
   end
+
+  if panel.keymap.close then
+    vim.keymap.set("n", panel.keymap.close, mod.teardown, {
+      buffer = bufnr,
+      desc = "[copilot] (panel) close",
+      silent = true,
+    })
+  end
 end
 
 function panel:ensure_bufnr()


### PR DESCRIPTION
This PR allows users to set a keymap for closing the panel that uses the existing `mod.teardown` method.