### PR TITLE
fix(client): always get error node version on `powershell`

### DIFF
--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -50,7 +50,8 @@ function M.get_node_version()
     local node = config.get("copilot_node_command")
 
     local cmd = node .. " --version"
-    local cmd_output = table.concat(vim.fn.systemlist(cmd, nil, false))
+    local cmd_output_table = vim.fn.systemlist(cmd, nil, false)
+    local cmd_output = cmd_output_table[#cmd_output_table]
     local cmd_exit_code = vim.v.shell_error
 
     local node_version = string.match(cmd_output, "^v(%S+)") or ""


### PR DESCRIPTION
`systemlist ` return 
``` 
**********************************************************************
 ** Visual Studio 2022 Developer PowerShell v17.5.3
 ** Copyright (c) 2022 Microsoft Corporation
 **********************************************************************
 v18.16.0
```
on `powershell`
so, should get last element in the `systemlist` result, or use a more precise regex.