### PR TITLE
get_node_version() not working with custom vim.opt.shell

### DIFF
--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -49,7 +49,7 @@ function M.get_node_version()
   if not M.node_version then
     local node = config.get("copilot_node_command")
 
-    local cmd = { "node", "--version" }
+    local cmd = { node, "--version" }
     local cmd_output_table = vim.fn.systemlist(cmd, nil, false)
     local cmd_output = cmd_output_table[#cmd_output_table]
     local cmd_exit_code = vim.v.shell_error

--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -49,7 +49,7 @@ function M.get_node_version()
   if not M.node_version then
     local node = config.get("copilot_node_command")
 
-    local cmd = node .. " --version"
+    local cmd = { "node", "--version" }
     local cmd_output_table = vim.fn.systemlist(cmd, nil, false)
     local cmd_output = cmd_output_table[#cmd_output_table]
     local cmd_exit_code = vim.v.shell_error


### PR DESCRIPTION
get_node_version() was not working for me with a custom vim.opt.shell.

Using a table instead of a concatenation solved the issue.