### PR TITLE
feat: Emit two user events during request suggestion

### DIFF
--- a/lua/copilot/suggestion.lua
+++ b/lua/copilot/suggestion.lua
@@ -317,9 +317,11 @@ local function handle_trigger_request(err, data)
   ctx.choice = 1
   ctx.shown_choices = {}
   update_preview()
+  vim.api.nvim_exec_autocmds("User", { pattern = "CopilotSuggestionCompleted", modeline = false })
 end
 
 local function trigger(bufnr, timer)
+  vim.api.nvim_exec_autocmds("User", { pattern = "CopilotRequestInitiated", modeline = false })
   local _timer = copilot._copilot_timer
   copilot._copilot_timer = nil
 


### PR DESCRIPTION
This feature enhancement allows the emission of two user events during the process of requesting a suggestion. 
- The first event, `CopilotRequestInitiated`, is triggered when the copilot request is initiated. 
- The second event, `CopilotSuggestionCompleted`, is triggered when the copilot suggestion process is completed. 