### PR TITLE
Fix E565 when using Tab as accept

### DIFF
--- a/lua/copilot/suggestion.lua
+++ b/lua/copilot/suggestion.lua
@@ -483,14 +483,16 @@ function mod.accept(modifier)
   end
 
   -- Hack for 'autoindent', makes the indent persist. Check `:help 'autoindent'`.
-  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Space><Left><Del>", true, false, true), "n", false)
-  vim.lsp.util.apply_text_edits({ { range = range, newText = newText } }, vim.api.nvim_get_current_buf(), "utf-16")
-  -- Put cursor at the end of current line.
-  local cursor_keys = "<End>"
-  if has_nvim_0_10_x then
-    cursor_keys = string.rep("<Down>", #vim.split(newText, "\n", { plain = true }) - 1) .. cursor_keys
-  end
-  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(cursor_keys, true, false, true), "n", false)
+  vim.schedule_wrap(function()
+    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Space><Left><Del>", true, false, true), "n", false)
+    vim.lsp.util.apply_text_edits({ { range = range, newText = newText } }, vim.api.nvim_get_current_buf(), "utf-16")
+    -- Put cursor at the end of current line.
+    local cursor_keys = "<End>"
+    if has_nvim_0_10_x then
+      cursor_keys = string.rep("<Down>", #vim.split(newText, "\n", { plain = true }) - 1) .. cursor_keys
+    end
+    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(cursor_keys, true, false, true), "n", false)
+  end)()
 end
 
 function mod.accept_word()


### PR DESCRIPTION
As described in issue #278 - when you are set up in like SuperTab, you get this error (E565) from the LSP util that you're not allowed to modify the buffer.

The TL;DR here (**I think**) is that you're trying to do a synchronous accept with the results from an asynchronous call.  The solution is to enqueue the accept on the event loop so that the text edit happens on the next tick (after whatever already enqueued async calls have already happened) rather than trying to do it on the "main thread"