### PR TITLE
Support non-full-width horizontal and vertical splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ require('copilot').setup({
       open = "<M-CR>"
     },
     layout = {
-      position = "bottom", -- | top | left | right
+      position = "bottom", -- | top | left | right | horizontal | vertical
       ratio = 0.4
     },
   },

--- a/lua/copilot/panel.lua
+++ b/lua/copilot/panel.lua
@@ -331,6 +331,8 @@ function panel:ensure_winid()
     right = { cmd_prefix = "vertical botright ", winsize_fn = get_width },
     bottom = { cmd_prefix = "botright ", winsize_fn = get_height },
     left = { cmd_prefix = "vertical topleft ", winsize_fn = get_width },
+    horizontal = { cmd_prefix = "horizontal ", winsize_fn = get_height },
+    vertical = { cmd_prefix = "vertical ", winsize_fn = get_width },
   }
 
   local split_info = split_map[position]
@@ -539,7 +541,7 @@ function mod.refresh()
 end
 
 ---@param layout {position: string, ratio: number}
----position: (optional) 'bottom' | 'top' | 'left' | 'right'
+---position: (optional) 'bottom' | 'top' | 'left' | 'right' | 'horizontal' | 'vertical'
 ---ratio: (optional) between 0 and 1
 function mod.open(layout)
   local client = c.get()


### PR DESCRIPTION
The "bottom" and "right" options create full-width splits. This change adds options to split only the current window horizontally or vertically, which is the default vim behavior when splitting.