### PR TITLE
fix: esm package traversal

### DIFF
--- a/copilot/package.json
+++ b/copilot/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "copilot",
+  "version": "1.0.0",
+  "description": "Fully featured & enhanced replacement for copilot.vim complete with API for interacting with Github Copilot",
+  "author": "zbirenbaum",
+  "license": "MIT"
+}


### PR DESCRIPTION
Closes #306

I tested this by:
1. creating a `package.json` in my home dir
2. adding `"type": "module"`
3. opening nvim and see copilot crash
4. adding the `package.json` see in the diff to `~/.local/share/nvim/lazy/copilot.lua/copilot/package.json`
5. open nvim
6. observed no crashes 🥳