### PR TITLE
fix(suggestion): Trigger suggestion on InsertEnter

### DIFF
--- a/lua/copilot/suggestion.lua
+++ b/lua/copilot/suggestion.lua
@@ -324,7 +324,7 @@ local function trigger(bufnr, timer)
   local _timer = copilot._copilot_timer
   copilot._copilot_timer = nil
 
-  if bufnr ~= vim.api.nvim_get_current_buf() or timer ~= _timer or vim.fn.mode() ~= "i" then
+  if bufnr ~= vim.api.nvim_get_current_buf() or (_timer ~= nil and timer ~= _timer) or vim.fn.mode() ~= "i" then
     return
   end
 


### PR DESCRIPTION
This pull request make that the suggestion get triggered when entering insert mode.
It was not working because both `InsertEnter` and `CursorMovedI` would fire at the same time and the timer variable would be messed up in the debounce function like this:

- `InsertEnter` is called, `copilot.timer` is set to timer id 1
- `CursorMovedI` is called, `copilot.timer` is set to timer id 2
- Debounce function 1 is called, `timer` is 1, `copilot.timer` is 2, early return, `copilot.timer` is set to `nil`
- Debounce function 2 is called, `timer` is 2, `copilot.timer` is `nil`, early return

This pull requests fixes this, I'm testing this since yesterday and it's working fine, but I don't know the codebase very well so I'm hoping I'm not breaking something.

Also the debounce function doesn't seem to be working (with or without this pull request), it works only as a timeout, does this need to be fixed or is this the intended behavior?