### PR TITLE
Update Copilot to use language-server.js

### DIFF
--- a/lua/copilot/command.lua
+++ b/lua/copilot/command.lua
@@ -10,7 +10,7 @@ local function node_version_warning(node_version)
     local line = "Warning: Node.js 16 is approaching end of life and support will be dropped in a future release."
     if config.get("copilot_node_command") ~= "node" then
       line = line
-        .. " 'copilot_node_command' is set to a non-default value. Consider removing it from your configuration."
+          .. " 'copilot_node_command' is set to a non-default value. Consider removing it from your configuration."
     end
     return { line, "MoreMsg" }
   end
@@ -31,9 +31,9 @@ function mod.version()
   coroutine.wrap(function()
     if client then
       local _, data = a.get_version(client)
-      lines[#lines + 1] = "copilot/dist/agent.js" .. " " .. data.version
+      lines[#lines + 1] = "copilot/dist/language-server.js" .. " " .. data.version
     else
-      lines[#lines + 1] = "copilot/dist/agent.js" .. " " .. "not running"
+      lines[#lines + 1] = "copilot/dist/language-server.js" .. " " .. "not running"
     end
 
     local node_version, node_version_error = c.get_node_version()

--- a/lua/copilot/suggestion.lua
+++ b/lua/copilot/suggestion.lua
@@ -5,7 +5,7 @@ local hl_group = require("copilot.highlight").group
 local util = require("copilot.util")
 
 local _, has_nvim_0_10_x = pcall(function()
-  return vim.version().minor == 10
+  return vim.version().minor >= 10
 end)
 
 local mod = {}
@@ -196,11 +196,11 @@ local function get_current_suggestion(ctx)
 
   local ok, choice = pcall(function()
     if
-      not vim.fn.mode():match("^[iR]")
-      or (copilot.hide_during_completion and vim.fn.pumvisible() == 1)
-      or vim.b.copilot_suggestion_hidden
-      or not ctx.suggestions
-      or #ctx.suggestions == 0
+        not vim.fn.mode():match("^[iR]")
+        or (copilot.hide_during_completion and vim.fn.pumvisible() == 1)
+        or vim.b.copilot_suggestion_hidden
+        or not ctx.suggestions
+        or #ctx.suggestions == 0
     then
       return nil
     end
@@ -250,7 +250,7 @@ local function update_preview(ctx)
   local cursor_col = vim.fn.col(".")
 
   displayLines[1] =
-    string.sub(string.sub(suggestion.text, 1, (string.find(suggestion.text, "\n", 1, true) or 0) - 1), cursor_col)
+      string.sub(string.sub(suggestion.text, 1, (string.find(suggestion.text, "\n", 1, true) or 0) - 1), cursor_col)
 
   local extmark = {
     id = copilot.extmark_id,


### PR DESCRIPTION
- **fix: rename agent.js to language-server.js**
- **fix: enable nvim v0.10 features in v0.11+ versions**
