### PR TITLE
fix(panel): avoid being stuck "loading"

### DIFF
--- a/lua/copilot/panel.lua
+++ b/lua/copilot/panel.lua
@@ -469,6 +469,9 @@ function panel:refresh()
     params.position.character = params.doc.position.character
   end
 
+  -- on_solutions_done can be invoked before the api.get_panel_completions callback
+  self.state.status = "loading"
+
   local _, id = api.get_panel_completions(
     self.client,
     params,
@@ -481,7 +484,6 @@ function panel:refresh()
         return
       end
 
-      self.state.status = "loading"
       self.state.expected_count = result.solutionCountTarget
       panel:unlock():refresh_header():lock()
     end


### PR DESCRIPTION
Whenever the Copilot LSP knows it's not going to provide any suggestions, it replies with PanelSolutionsDone even before it completes the request. This resulted in us setting the status to "done" and then immediately resetting it to "loading", and thus getting stuck on "loading".

The fix is to set the status to "loading" in the initial refresh call itself to avoid the race between on_solutions_done and the get_panel_completions callback.
