### PR TITLE
fix: wrong buffer encoding breaks accepting suggestions

### DIFF
--- a/lua/copilot/suggestion.lua
+++ b/lua/copilot/suggestion.lua
@@ -486,7 +486,9 @@ function mod.accept(modifier)
   -- Hack for 'autoindent', makes the indent persist. Check `:help 'autoindent'`.
   vim.schedule_wrap(function()
     vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Space><Left><Del>", true, false, true), "n", false)
-    vim.lsp.util.apply_text_edits({ { range = range, newText = newText } }, vim.api.nvim_get_current_buf(), "utf-16")
+      local bufnr = vim.api.nvim_get_current_buf()
+    local encoding = vim.api.nvim_get_option_value('fileencoding', { buf = bufnr })
+    vim.lsp.util.apply_text_edits({ { range = range, newText = newText } }, bufnr, encoding)
     -- Put cursor at the end of current line.
     local cursor_keys = "<End>"
     if has_nvim_0_10_x then


### PR DESCRIPTION
These changes ensure that the text edits are applied using the correct encoding for the current buffer, improving compatibility with different file encodings.

The changes made in the `suggestion.lua` file are as follows:

1. **Dynamic Encoding Retrieval**:
   - The code now dynamically retrieves the file encoding of the current buffer using `vim.api.nvim_get_option_value('fileencoding', { buf = bufnr })`.
   - This replaces the previous hardcoded "utf-16" encoding.

2. **Buffer Number Handling**:
   - The current buffer number is stored in the `bufnr` variable using `vim.api.nvim_get_current_buf()`.
   - This buffer number is then used to retrieve the encoding and apply text edits.

