### PR TITLE
fix(client): filetype can be nil on nightly for get_language_id

### DIFF
--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -194,7 +194,8 @@ local function prepare_client_config(overrides)
     root_dir = vim.loop.cwd(),
     name = "copilot",
     capabilities = capabilities,
-    get_language_id = function(_, filetype)
+    get_language_id = function(buf, filetype)
+      filetype = filetype or vim.bo[buf].filetype
       return util.language_for_file_type(filetype)
     end,
     on_init = function(client, initialize_result)


### PR DESCRIPTION
See https://github.com/neovim/neovim/issues/31262