### PR TITLE
fix(util): error when filetype is nil

### DIFF
--- a/lua/copilot/util.lua
+++ b/lua/copilot/util.lua
@@ -139,10 +139,10 @@ local language_normalization_map = {
 }
 
 function M.language_for_file_type(filetype)
-  -- trim filetypes after dot, e.g. `yaml.gotexttmpl` -> `yaml`
-  local ft = string.gsub(filetype, "%..*", "")
-  if not ft or ft == "" then
-    ft = "text"
+  local ft = "text"
+  if filetype then
+    -- trim filetypes after dot, e.g. `yaml.gotexttmpl` -> `yaml`
+    ft = string.gsub(filetype, "%..*", "") or "text"
   end
   return language_normalization_map[ft] or ft
 end


### PR DESCRIPTION
Hi, on latest nvim `v0.11.0-dev-1190+gc12be1249f` this PR fixes the following issue, preventing Copilot to work

```
Error executing vim.schedule lua callback: ...e/.local/share/nvim/dev/copilot.lua/lua/copilot/util.lua:143: bad argument #1 to 'gsub' (string expected, got
nil)
stack traceback:
        [C]: in function 'gsub'
        ...e/.local/share/nvim/dev/copilot.lua/lua/copilot/util.lua:143: in function 'get_language_id'
        /usr/share/nvim/runtime/lua/vim/lsp/client.lua:1030: in function '_text_document_did_open_handler'
        /usr/share/nvim/runtime/lua/vim/lsp/client.lua:1049: in function '_on_attach'
        /usr/share/nvim/runtime/lua/vim/lsp/client.lua:631: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

