### PR TITLE
fix: Handle empty fileencoding by falling back to global encoding

### DIFF
--- a/lua/copilot/suggestion.lua
+++ b/lua/copilot/suggestion.lua
@@ -487,7 +487,9 @@ function mod.accept(modifier)
   vim.schedule_wrap(function()
     vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Space><Left><Del>", true, false, true), "n", false)
       local bufnr = vim.api.nvim_get_current_buf()
-    local encoding = vim.api.nvim_get_option_value('fileencoding', { buf = bufnr })
+    local encoding = vim.api.nvim_get_option_value("fileencoding", { buf = bufnr }) ~= ""
+        and vim.api.nvim_get_option_value("fileencoding", { buf = bufnr })
+      or vim.api.nvim_get_option_value("encoding", { scope = "global" })
     vim.lsp.util.apply_text_edits({ { range = range, newText = newText } }, bufnr, encoding)
     -- Put cursor at the end of current line.
     local cursor_keys = "<End>"


### PR DESCRIPTION
## Description

This fix addresses an issue where an error occurs if the buffer's `fileencoding` option is empty during certain operations, such as applying text edits in the LSP. (#344)

## Context

While similar issues regarding file encodings have been reported and resolved, this specific case occurs when the `fileencoding` of a buffer is not explicitly set. In such cases, the empty string (`""`) is returned, leading to failures in functions that expect a valid encoding (e.g., `vim.lsp.util.apply_text_edits`).

## Changes

- Added a fallback mechanism to use the global `encoding` option (`vim.o.encoding`) if `fileencoding` is empty.
- Ensured that the user’s configuration for `encoding` is respected before defaulting to `"utf-8"`.

## Steps to Reproduce

1. Open a new file in Neovim (e.g., `nvim newfile.txt`).
2. Without saving the file or setting `fileencoding`, trigger an operation that depends on the file's encoding, such as applying LSP edits.
3. Observe the error due to the empty `fileencoding`.

## Fix Explanation

The fix retrieves the `fileencoding` value for the buffer and checks if it is empty. If it is, the global `encoding` setting is used as a fallback. This ensures that the operation continues with a valid encoding, avoiding errors.
