### PR TITLE
fix: prevent agent service not initialized

### DIFF
--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -12,6 +12,7 @@ local M = {
   node_version = nil,
   node_version_error = nil,
   startup_error = nil,
+  initialized = false,
 }
 
 ---@param id number
@@ -216,6 +217,7 @@ local function prepare_client_config(overrides)
             vim.notify(string.format("[copilot] setEditorInfo failure: %s", err), vim.log.levels.ERROR)
           end
         end)
+        M.initialized = true
       end)
     end,
     on_exit = function(code, _signal, client_id)

--- a/lua/copilot/suggestion.lua
+++ b/lua/copilot/suggestion.lua
@@ -402,7 +402,7 @@ local function advance(count, ctx)
 end
 
 local function schedule(ctx)
-  if not is_enabled() then
+  if not is_enabled() or not c.initialized then
     clear()
     return
   end


### PR DESCRIPTION
No PR dependencies on this one, seemed like a simple race condition with the async setEditorInfo call happening after trying to get suggestions.

fixes #321