### PR TITLE
fix missing stdio param

### DIFF
--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -190,6 +190,7 @@ local function prepare_client_config(overrides)
     cmd = {
       node,
       agent_path,
+      '--stdio'
     },
     root_dir = vim.loop.cwd(),
     name = "copilot",


### PR DESCRIPTION
add `--stdio` to end of command. Having some trouble with getting completions to appear even though executable is running so may have to revert #372
