### PR TITLE
fix: avoid LSP error with unsupported window/logMessage

### DIFF
--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -222,29 +222,6 @@ local function prepare_client_config(overrides)
     PanelSolutionsDone = api.handlers.PanelSolutionsDone,
     statusNotification = api.handlers.statusNotification,
     ["copilot/openURL"] = api.handlers["copilot/openURL"],
-    -- set up "window/logMessage" handler here instead of in `logger.lua`, since some other lsp servers don't support this method, such as jsonlsp
-    ["window/logMessage"] = function(_, result, _)
-      if not result then
-        return
-      end
-
-      local message = string.format("LSP message: %s", result.message)
-      local message_type = result.type --[[@as integer]]
-
-      if message_type == 1 then
-        logger.error(message)
-      elseif message_type == 2 then
-        logger.warn(message)
-      elseif message_type == 3 then
-        logger.info(message)
-      elseif message_type == 4 then
-        logger.info(message)
-      elseif message_type == 5 then
-        logger.debug(message)
-      else
-        logger.trace(message)
-      end
-    end,
   }
 
   local root_dir = config.get_root_dir()

--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -272,6 +272,8 @@ local function prepare_client_config(overrides)
     end
   end
 
+  local editor_info = util.get_editor_info()
+
   -- LSP config, not to be confused with config.lua
   return vim.tbl_deep_extend("force", {
     cmd = {
@@ -326,6 +328,9 @@ local function prepare_client_config(overrides)
     handlers = handlers,
     init_options = {
       copilotIntegrationId = "vscode-chat",
+      -- Fix LSP warning: editorInfo and editorPluginInfo will soon be required in initializationOptions
+      editorInfo = editor_info.editorInfo,
+      editorPluginInfo = editor_info.editorPluginInfo,
     },
     workspace_folders = workspace_folders,
     trace = config.get("trace") or "off",

--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -23,8 +23,7 @@ local M = {
 local function store_client_id(id)
   if M.id and M.id ~= id then
     if vim.lsp.get_client_by_id(M.id) then
-      logger.error("unexpectedly started multiple copilot servers")
-      return
+      vim.lsp.stop_client(M.id)
     end
   end
 
@@ -170,7 +169,7 @@ function M.use_client(callback)
     return
   end
 
-  local timer, err, _ = vim.loop.new_timer()
+  local timer, err, _ = vim.uv.new_timer()
 
   if not timer then
     logger.error(string.format("error creating timer: %s", err))

--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -222,6 +222,29 @@ local function prepare_client_config(overrides)
     PanelSolutionsDone = api.handlers.PanelSolutionsDone,
     statusNotification = api.handlers.statusNotification,
     ["copilot/openURL"] = api.handlers["copilot/openURL"],
+    -- set up "window/logMessage" handler here instead of in `logger.lua`, since some other lsp servers don't support this method, such as jsonlsp
+    ["window/logMessage"] = function(_, result, _)
+      if not result then
+        return
+      end
+
+      local message = string.format("LSP message: %s", result.message)
+      local message_type = result.type --[[@as integer]]
+
+      if message_type == 1 then
+        logger.error(message)
+      elseif message_type == 2 then
+        logger.warn(message)
+      elseif message_type == 3 then
+        logger.info(message)
+      elseif message_type == 4 then
+        logger.info(message)
+      elseif message_type == 5 then
+        logger.debug(message)
+      else
+        logger.trace(message)
+      end
+    end,
   }
 
   local root_dir = config.get_root_dir()

--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -329,6 +329,8 @@ local function prepare_client_config(overrides)
     init_options = {
       copilotIntegrationId = "vscode-chat",
       -- Fix LSP warning: editorInfo and editorPluginInfo will soon be required in initializationOptions
+      -- We are sending these twice for the time being as it will become required here and we get a warning if not set.
+      -- However if not passed in setEditorInfo, that one returns an error.
       editorInfo = editor_info.editorInfo,
       editorPluginInfo = editor_info.editorPluginInfo,
     },

--- a/lua/copilot/logger.lua
+++ b/lua/copilot/logger.lua
@@ -147,29 +147,6 @@ function mod.setup(conf)
       mod.trace(string.format("LSP progress - token %s", result.token), result.value)
     end
   end
-
-  vim.lsp.handlers["window/logMessage"] = function(_, result, _)
-    if not result then
-      return
-    end
-
-    local message = string.format("LSP message: %s", result.message)
-    local message_type = result.type --[[@as integer]]
-
-    if message_type == 1 then
-      mod.error(message)
-    elseif message_type == 2 then
-      mod.warn(message)
-    elseif message_type == 3 then
-      mod.info(message)
-    elseif message_type == 4 then
-      mod.info(message)
-    elseif message_type == 5 then
-      mod.debug(message)
-    else
-      mod.trace(message)
-    end
-  end
 end
 
 return mod

--- a/lua/copilot/logger.lua
+++ b/lua/copilot/logger.lua
@@ -147,6 +147,29 @@ function mod.setup(conf)
       mod.trace(string.format("LSP progress - token %s", result.token), result.value)
     end
   end
+
+  vim.lsp.handlers["window/logMessage"] = function(_, result, _)
+    if not result then
+      return
+    end
+
+    local message = string.format("LSP message: %s", result.message)
+    local message_type = result.type --[[@as integer]]
+
+    if message_type == 1 then
+      mod.error(message)
+    elseif message_type == 2 then
+      mod.warn(message)
+    elseif message_type == 3 then
+      mod.info(message)
+    elseif message_type == 4 then
+      mod.info(message)
+    elseif message_type == 5 then
+      mod.debug(message)
+    else
+      mod.trace(message)
+    end
+  end
 end
 
 return mod


### PR DESCRIPTION
Some LSP servers like jsonlsp don't support window/logMessage method, causing potential errors. Move the handler to client config to avoid this.
Fixes #389 