### PR TITLE
fix: avoid LSP error with unsupported window/logMessage

### DIFF
--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -222,6 +222,29 @@ local function prepare_client_config(overrides)
     PanelSolutionsDone = api.handlers.PanelSolutionsDone,
     statusNotification = api.handlers.statusNotification,
     ["copilot/openURL"] = api.handlers["copilot/openURL"],
+    -- set up "window/logMessage" handler here instead of in `logger.lua`, since some other lsp servers don't support this method, such as jsonlsp
+    ["window/logMessage"] = function(_, result, _)
+      if not result then
+        return
+      end
+
+      local message = string.format("LSP message: %s", result.message)
+      local message_type = result.type --[[@as integer]]
+
+      if message_type == 1 then
+        logger.error(message)
+      elseif message_type == 2 then
+        logger.warn(message)
+      elseif message_type == 3 then
+        logger.info(message)
+      elseif message_type == 4 then
+        logger.info(message)
+      elseif message_type == 5 then
+        logger.debug(message)
+      else
+        logger.trace(message)
+      end
+    end,
   }
 
   local root_dir = config.get_root_dir()

--- a/lua/copilot/logger.lua
+++ b/lua/copilot/logger.lua
@@ -147,29 +147,6 @@ function mod.setup(conf)
       mod.trace(string.format("LSP progress - token %s", result.token), result.value)
     end
   end
-
-  vim.lsp.handlers["window/logMessage"] = function(_, result, _)
-    if not result then
-      return
-    end
-
-    local message = string.format("LSP message: %s", result.message)
-    local message_type = result.type --[[@as integer]]
-
-    if message_type == 1 then
-      mod.error(message)
-    elseif message_type == 2 then
-      mod.warn(message)
-    elseif message_type == 3 then
-      mod.info(message)
-    elseif message_type == 4 then
-      mod.info(message)
-    elseif message_type == 5 then
-      mod.debug(message)
-    else
-      mod.trace(message)
-    end
-  end
 end
 
 return mod


### PR DESCRIPTION
Some LSP servers like jsonlsp don't support window/logMessage method, causing potential errors. Move the handler to client config to avoid this. 
Fixes #389