### PR TITLE
chore: remove unused editor info fields from copilot_set_editor_info_params

### DIFF
--- a/lua/copilot/api.lua
+++ b/lua/copilot/api.lua
@@ -32,7 +32,7 @@ end
 ---@alias copilot_editor_plugin_info { name: string, version: string }
 ---@alias copilot_auth_provider { url: string }
 ---@alias copilot_network_proxy { host: string, port: integer, username?: string, password?: string, rejectUnauthorized?: boolean }
----@alias copilot_set_editor_info_params { editorInfo: copilot_editor_info, editorPluginInfo: copilot_editor_plugin_info, editorConfiguration: copilot_editor_configuration, networkProxy?: copilot_network_proxy, authProvider?: copilot_auth_provider }
+---@alias copilot_set_editor_info_params { editorConfiguration: copilot_editor_configuration, networkProxy?: copilot_network_proxy, authProvider?: copilot_auth_provider }
 
 ---@param params copilot_set_editor_info_params
 ---@return any|nil err

--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -293,7 +293,7 @@ local function prepare_client_config(overrides)
       end
 
       vim.schedule(function()
-        local set_editor_info_params = util.get_editor_info() --[[@as copilot_set_editor_info_params]]
+        local set_editor_info_params = {} --[[@as copilot_set_editor_info_params]]
         set_editor_info_params.editorConfiguration = util.get_editor_configuration()
         set_editor_info_params.networkProxy = util.get_network_proxy()
         local provider_url = config.get("auth_provider_url")


### PR DESCRIPTION
Tidy up `copilot_set_editor_info_params` after `editorInfo` and `editorPluginInfo` have been moved to init options (commit 1f893df)