### PR TITLE
logging and performance improvements

### DIFF
--- a/lua/copilot/api.lua
+++ b/lua/copilot/api.lua
@@ -1,3 +1,4 @@
+local logger = require("copilot.logger")
 local mod = {}
 
 ---@param callback? fun(err: any|nil, data: table, ctx: table): nil
@@ -5,6 +6,7 @@ local mod = {}
 ---@return table data
 ---@return table ctx
 function mod.request(client, method, params, callback)
+  logger.trace("api request:", method, params)
   -- hack to convert empty table to json object,
   -- empty table is convert to json array by default.
   params._ = true
@@ -25,6 +27,7 @@ end
 
 ---@return boolean sent
 function mod.notify(client, method, params)
+  logger.trace("api notify:", method, params)
   return client.notify(method, params)
 end
 

--- a/lua/copilot/api.lua
+++ b/lua/copilot/api.lua
@@ -53,6 +53,13 @@ function mod.notify_change_configuration(client, params)
   return mod.notify(client, "notifyChangeConfiguration", params)
 end
 
+---@alias copilot_nofify_set_trace_params { value: 'off'|'messages'|'verbose' }
+
+---@param params copilot_nofify_set_trace_params
+function mod.notify_set_trace(client, params)
+  return mod.notify(client, "$/setTrace", params)
+end
+
 ---@alias copilot_check_status_params { options?: { localChecksOnly?: boolean } }
 ---@alias copilot_check_status_data { user?: string, status: 'OK'|'NotAuthorized'|'NoTelemetryConsent' }
 

--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -309,6 +309,12 @@ local function prepare_client_config(overrides)
           end
         end)
         logger.trace("setEditorInfo has been called")
+
+        local logger_conf = config.get("logger") --[[@as copilot_config_logging]]
+        local trace_params = { value = logger_conf.trace_lsp } --[[@as copilot_nofify_set_trace_params]]
+        logger.trace("data for setTrace LSP call", trace_params)
+        api.notify_set_trace(client, trace_params)
+
         M.initialized = true
       end)
     end,

--- a/lua/copilot/suggestion.lua
+++ b/lua/copilot/suggestion.lua
@@ -428,6 +428,11 @@ local function schedule(ctx)
   end
   logger.trace("suggestion schedule", ctx)
 
+  if copilot._copilot_timer then
+    cancel_inflight_requests(ctx)
+    stop_timer()
+  end
+
   update_preview(ctx)
   local bufnr = vim.api.nvim_get_current_buf()
   copilot._copilot_timer = vim.fn.timer_start(copilot.debounce, function(timer)

--- a/lua/copilot/suggestion.lua
+++ b/lua/copilot/suggestion.lua
@@ -51,15 +51,18 @@ end
 local function get_ctx(bufnr)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
   local ctx = copilot.context[bufnr]
+  logger.trace("suggestion context", ctx)
   if not ctx then
     ctx = {}
     copilot.context[bufnr] = ctx
+    logger.trace("suggestion new context", ctx)
   end
   return ctx
 end
 
 ---@param ctx copilot_suggestion_context
 local function reset_ctx(ctx)
+  logger.trace("suggestion reset context", ctx)
   ctx.first = nil
   ctx.cycling = nil
   ctx.cycling_callbacks = nil
@@ -149,6 +152,7 @@ end
 
 local function stop_timer()
   if copilot._copilot_timer then
+    logger.trace("suggestion stop timer")
     vim.fn.timer_stop(copilot._copilot_timer)
     copilot._copilot_timer = nil
   end
@@ -172,28 +176,34 @@ end
 
 ---@param ctx? copilot_suggestion_context
 local function cancel_inflight_requests(ctx)
+  logger.trace("suggestion cancel inflight requests", ctx)
   ctx = ctx or get_ctx()
 
   with_client(function(client)
     if ctx.first then
       client.cancel_request(ctx.first)
       ctx.first = nil
+      logger.trace("suggestion cancel first request")
     end
     if ctx.cycling then
       client.cancel_request(ctx.cycling)
       ctx.cycling = nil
+      logger.trace("suggestion cancel cycling request")
     end
   end)
 end
 
 local function clear_preview()
+  logger.trace("suggestion clear preview")
   vim.api.nvim_buf_del_extmark(0, copilot.ns_id, copilot.extmark_id)
 end
 
 ---@param ctx? copilot_suggestion_context
 ---@return copilot_get_completions_data_completion|nil
 local function get_current_suggestion(ctx)
+  logger.trace("suggestion get current suggestion", ctx)
   ctx = ctx or get_ctx()
+  logger.trace("suggestion current suggestion", ctx)
 
   local ok, choice = pcall(function()
     if
@@ -229,6 +239,7 @@ end
 ---@param ctx? copilot_suggestion_context
 local function update_preview(ctx)
   ctx = ctx or get_ctx()
+  logger.trace("suggestion update preview", ctx)
 
   local suggestion = get_current_suggestion(ctx)
   local displayLines = suggestion and vim.split(suggestion.displayText, "\n", { plain = true }) or {}
@@ -286,6 +297,7 @@ end
 
 ---@param ctx? copilot_suggestion_context
 local function clear(ctx)
+  logger.trace("suggestion clear", ctx)
   ctx = ctx or get_ctx()
   stop_timer()
   cancel_inflight_requests(ctx)
@@ -295,6 +307,7 @@ end
 
 ---@param callback fun(err: any|nil, data: copilot_get_completions_data): nil
 local function complete(callback)
+  logger.trace("suggestion complete")
   stop_timer()
 
   local ctx = get_ctx()
@@ -314,6 +327,7 @@ local function handle_trigger_request(err, data)
   if err then
     logger.error(err)
   end
+  logger.trace("suggestion handle trigger request", data)
   local ctx = get_ctx()
   ctx.suggestions = data and data.completions or {}
   ctx.choice = 1
@@ -322,10 +336,12 @@ local function handle_trigger_request(err, data)
 end
 
 local function trigger(bufnr, timer)
+  logger.trace("suggestion trigger", bufnr)
   local _timer = copilot._copilot_timer
   copilot._copilot_timer = nil
 
   if bufnr ~= vim.api.nvim_get_current_buf() or (_timer ~= nil and timer ~= _timer) or vim.fn.mode() ~= "i" then
+    logger.trace("suggestion trigger, not in insert mode")
     return
   end
 
@@ -334,6 +350,7 @@ end
 
 ---@param ctx copilot_suggestion_context
 local function get_suggestions_cycling_callback(ctx, err, data)
+  logger.trace("suggestion get suggestions cycling callback", data)
   local callbacks = ctx.cycling_callbacks or {}
   ctx.cycling_callbacks = nil
 
@@ -367,6 +384,8 @@ end
 ---@param callback fun(ctx: copilot_suggestion_context): nil
 ---@param ctx copilot_suggestion_context
 local function get_suggestions_cycling(callback, ctx)
+  logger.trace("suggestion get suggestions cycling", ctx)
+
   if ctx.cycling_callbacks then
     table.insert(ctx.cycling_callbacks, callback)
     return
@@ -407,19 +426,23 @@ local function schedule(ctx)
     clear()
     return
   end
+  logger.trace("suggestion schedule", ctx)
 
   update_preview(ctx)
   local bufnr = vim.api.nvim_get_current_buf()
   copilot._copilot_timer = vim.fn.timer_start(copilot.debounce, function(timer)
+    logger.trace("suggestion schedule timer", bufnr)
     trigger(bufnr, timer)
   end)
 end
 
 function mod.next()
   local ctx = get_ctx()
+  logger.trace("suggestion next", ctx)
 
   -- no suggestion request yet
   if not ctx.first then
+    logger.trace("suggestion next, no first request")
     schedule(ctx)
     return
   end
@@ -431,9 +454,11 @@ end
 
 function mod.prev()
   local ctx = get_ctx()
+  logger.trace("suggestion prev", ctx)
 
   -- no suggestion request yet
   if not ctx.first then
+    logger.trace("suggestion prev, no first request", ctx)
     schedule(ctx)
     return
   end
@@ -446,9 +471,11 @@ end
 ---@param modifier? (fun(suggestion: copilot_get_completions_data_completion): copilot_get_completions_data_completion)
 function mod.accept(modifier)
   local ctx = get_ctx()
+  logger.trace("suggestion accept", ctx)
 
   -- no suggestion request yet
   if not ctx.first then
+    logger.trace("suggestion accept, not first request", ctx)
     schedule(ctx)
     return
   end
@@ -466,7 +493,7 @@ function mod.accept(modifier)
   end
 
   with_client(function(client)
-    local ok, err = pcall(function()
+    local ok, _ = pcall(function()
       api.notify_accepted(
         client,
         { uuid = suggestion.uuid, acceptedLength = util.strutf16len(suggestion.text) },
@@ -568,6 +595,7 @@ end
 
 local function on_insert_enter()
   if should_auto_trigger() then
+    logger.trace("suggestion on insert enter")
     schedule()
   end
 end
@@ -581,6 +609,7 @@ end
 local function on_cursor_moved_i()
   local ctx = get_ctx()
   if copilot._copilot_timer or ctx.params or should_auto_trigger() then
+    logger.trace("suggestion on cursor moved insert")
     schedule(ctx)
   end
 end
@@ -588,6 +617,7 @@ end
 local function on_text_changed_p()
   local ctx = get_ctx()
   if not copilot.hide_during_completion and (copilot._copilot_timer or ctx.params or should_auto_trigger()) then
+    logger.trace("suggestion on text changed pum")
     schedule(ctx)
   end
 end


### PR DESCRIPTION
Add tracing logs, ensure logTrace enables it in the LSP and cancel the suggestion debounce timer when a new request is sent to prevent calling the LSP multiple times for the same info.