### PR TITLE
fix: Using js server when on musl

### DIFF
--- a/lua/copilot/lsp_binary.lua
+++ b/lua/copilot/lsp_binary.lua
@@ -199,7 +199,7 @@ function M.ensure_client_is_downloaded()
   local plugin_path = vim.fs.normalize(util.get_plugin_path())
   local copilot_server_info = M.get_copilot_server_info()
   local download_filename =
-      string.format("copilot-language-server-%s-%s.zip", copilot_server_info.path, copilot_version)
+    string.format("copilot-language-server-%s-%s.zip", copilot_server_info.path, copilot_version)
   local url = string.format(
     "https://github.com/github/copilot-language-server-release/releases/download/%s/%s",
     copilot_version,
@@ -207,7 +207,7 @@ function M.ensure_client_is_downloaded()
   )
   local local_server_zip_path = vim.fs.joinpath(plugin_path, "copilot/", copilot_server_info.path)
   local local_server_zip_filepath =
-      vim.fs.joinpath(plugin_path, "copilot/", copilot_server_info.path, download_filename)
+    vim.fs.joinpath(plugin_path, "copilot/", copilot_server_info.path, download_filename)
 
   logger.trace("copilot_server_info: ", copilot_server_info)
 
@@ -232,7 +232,6 @@ function M.ensure_client_is_downloaded()
     end
     delete_all_except(copilot_server_info.absolute_path, copilot_server_info.filename)
   end
-
 
   logger.notify("copilot-language-server downloaded")
   return true


### PR DESCRIPTION
Hello,
I just saw you reverted the changes, but this pull request could be used as a base to make the integration with the official binaries. Maybe we can work a little on this one to create the `beta` branch you were mentioning in https://github.com/zbirenbaum/copilot.lua/issues/408

## Summary
Official binaries do not work on `musl` systems (ie. *alpine* or *void*). This PR detects the libc setting and fallbacks to the default js language-server. 

Maybe, we can add a configuration option to allow users to decide to use the `js` version rather than the binary.

**NB**: i left commented the download functions for a different PR