### PR TITLE
fix: expand custom server path and skip download if set

### DIFF
--- a/lua/copilot/client.lua
+++ b/lua/copilot/client.lua
@@ -213,8 +213,11 @@ local function prepare_client_config(overrides)
   local server_path = nil
   local cmd = nil
 
-  if M.server.custom_server_filepath and vim.fn.filereadable(M.server.custom_server_filepath) then
-    server_path = M.server.custom_server_filepath
+  if M.server.custom_server_filepath then
+    M.server.custom_server_filepath = vim.fs.normalize(M.server.custom_server_filepath)
+    if vim.fn.filereadable(M.server.custom_server_filepath) then
+      server_path = M.server.custom_server_filepath
+    end
   end
 
   if M.server.type == "nodejs" then
@@ -371,11 +374,13 @@ function M.setup()
     end),
   })
 
-  vim.schedule(function()
-    if lsp_binary.ensure_client_is_downloaded() then
-      M.buf_attach()
-    end
-  end)
+  if not M.server.custom_server_filepath then
+    vim.schedule(function()
+      if lsp_binary.ensure_client_is_downloaded() then
+        M.buf_attach()
+      end
+    end)
+  end
 end
 
 function M.teardown()


### PR DESCRIPTION
This commit fixes the issue where the custom server path is not expanded when set in the configuration and ensures "~" and environment variables are expanded correctly. Additionally, it skips the download of the server if the custom server path is provided, allowing users to use their own server binary without triggering the download process.

Related: https://github.com/zbirenbaum/copilot.lua/issues/408#issuecomment-2763385890