### PR TITLE
fix: highlighting of suggestions may become "MatchParen" under certai…

### DIFF
--- a/lua/copilot/suggestion/init.lua
+++ b/lua/copilot/suggestion/init.lua
@@ -340,7 +340,7 @@ local function update_preview(ctx)
     extmark.virt_text[3] = { annot, hl_group.CopilotAnnotation }
   end
 
-  extmark.hl_mode = "combine"
+  extmark.hl_mode = "replace"
   vim.api.nvim_buf_set_extmark(0, copilot.ns_id, vim.fn.line(".") - 1, cursor_col - 1, extmark)
 
   if config.suggestion.suggestion_notification then


### PR DESCRIPTION
As shown in the attached video, under specific conditions when moving inside parentheses, the displayed completion adopts the "MatchParen" highlight.

https://github.com/user-attachments/assets/4cf5433c-c325-4290-b12d-6fa155604cbb

I resolved this issue by changing `extmark.hl_mode` from "combine" to "replace".

https://github.com/user-attachments/assets/ae73a396-e9d4-4150-b5e0-9b764f20957b

While I'm not certain if this approach is the most appropriate, I felt that unifying the highlight to "CopilotSuggestion" for completions displayed as virtual text wouldn't cause any inconsistency, so I created this PR.
