### PR TITLE
fix: call lsp.start after loading buffer

### DIFF
--- a/lua/copilot/init.lua
+++ b/lua/copilot/init.lua
@@ -23,7 +23,7 @@ M.setup = function(opts)
   local token_env_set = (os.getenv("GITHUB_COPILOT_TOKEN") ~= nil) or (os.getenv("GH_COPILOT_TOKEN") ~= nil)
 
   if token_env_set then
-    auth.signin()
+    vim.schedule(auth.signin)
   end
 
   M.setup_done = true


### PR DESCRIPTION
Without lazy loading `copilot.setup()` is called before buffer 1 is actually loaded.

Then happens this call chain: copilot.setup - auth.signin - use_client - lsp.start - lsp.buf_attach_client, and the last one checks for loaded buffer using `api.nvim_buf_is_loaded(bufnr)`, fails and fail lsp.start which returns nothing as result and this sends `error starting LSP client: nil` notification to a user.

Fixes #507 