### PR TITLE
doc, README.md and .../panel/init.lua panel positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ require('copilot').setup({
       open = "<M-CR>"
     },
     layout = {
-      position = "bottom", -- | top | left | right | horizontal | vertical
+      position = "bottom", -- | top | left | right | bottom |
       ratio = 0.4
     },
   },

--- a/doc/copilot.txt
+++ b/doc/copilot.txt
@@ -118,7 +118,7 @@ Default configuration ~
           open = "<M-CR>"
         },
         layout = {
-          position = "bottom", -- | top | left | right | horizontal | vertical
+          position = "bottom", -- | top | left | right | bottom |
           ratio = 0.4
         },
       },

--- a/lua/copilot/panel/init.lua
+++ b/lua/copilot/panel/init.lua
@@ -320,8 +320,6 @@ function panel:ensure_winid()
     right = { cmd_prefix = "vertical botright ", winsize_fn = get_width },
     bottom = { cmd_prefix = "botright ", winsize_fn = get_height },
     left = { cmd_prefix = "vertical topleft ", winsize_fn = get_width },
-    horizontal = { cmd_prefix = "horizontal ", winsize_fn = get_height },
-    vertical = { cmd_prefix = "vertical ", winsize_fn = get_width },
   }
 
   local split_info = split_map[position]


### PR DESCRIPTION
In doc and README.md comments, and in .../panel/init.lua, change possible position values to match validation values in .../lua/copilot/config/panel.lua so as to avoid validation error on "horizontal' or "vertical".

Note: indeed, "horizontal" and "vertical" add no functionality.