### PR TITLE
Relax validation for copilot_node_command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 # Run all test files
-# test: deps/mini.nvim
-test: 
+test: deps/mini.nvim
 	nvim --headless --noplugin -u ./tests/scripts/minimal_init.lua -c "lua MiniTest.run()"
 
 # Run test from file at `$FILE` environment variable
@@ -8,7 +7,7 @@ test_file: deps/mini.nvim
 	nvim --headless --noplugin -u ./tests/scripts/minimal_init.lua -c "lua MiniTest.run_file('$(FILE)')"
 
 # Download 'mini.nvim' to use its 'mini.test' testing module
-# deps/mini.nvim:
-# 	@mkdir deps
-# 	git clone --filter=blob:none https://github.com/echasnovski/mini.nvim deps/mini.nvim 
-# 	git clone https://github.com/jbyuki/one-small-step-for-vimkind deps/osv
+deps/mini.nvim:
+	@mkdir -p deps
+	git clone --filter=blob:none https://github.com/echasnovski/mini.nvim deps/mini.nvim
+	git clone https://github.com/jbyuki/one-small-step-for-vimkind deps/osv

--- a/lua/copilot/lsp/nodejs.lua
+++ b/lua/copilot/lsp/nodejs.lua
@@ -13,10 +13,10 @@ local M = {
 ---@return nil|string node_version_error
 function M.get_node_version()
   if not M.node_version then
-    local cmd = vim.split(M.node_command, " ")
-    table.insert(cmd, "--version")
+    local version_cmd = vim.split(M.node_command, " ")
+    table.insert(version_cmd, "--version")
 
-    local process = vim.system(cmd)
+    local process = vim.system(version_cmd)
     local result = process:wait()
     local cmd_output = result.stdout or ""
     local cmd_exit_code = result.code
@@ -60,17 +60,6 @@ function M.validate_node_version()
   return true
 end
 
-function M.node_exists()
-  -- local node_exists = vim.fn.executable(M.node_command) == 1
-  --
-  -- if not node_exists then
-  --   logger.error("node.js is not installed or not in PATH")
-  --   return false
-  -- end
-
-  return true
-end
-
 ---@param server_path? string
 ---@return boolean
 function M.init_agent_path(server_path)
@@ -110,7 +99,7 @@ end
 function M.setup(node_command, custom_server_path)
   M.node_command = node_command or "node"
 
-  if not M.node_exists() or not M.validate_node_version() or not M.init_agent_path(custom_server_path) then
+  if not M.validate_node_version() or not M.init_agent_path(custom_server_path) then
     return false
   end
 


### PR DESCRIPTION
Resolves #498, where we found that `vim.fn.executable` does not allow commands that alias through version managers like `mise x node@24 --node`, which is a problem when working on a project that uses a node version older than 20.x.

This removes the `vim.fn.executable` checks and just relies on the `node --version` output to determine if the configured command is usable or not.