### PR TITLE
Allow to skip cycling on suggestion.next()

### DIFF
--- a/lua/copilot/suggestion/init.lua
+++ b/lua/copilot/suggestion/init.lua
@@ -453,6 +453,17 @@ local function get_suggestions_cycling(callback, ctx)
   end
 end
 
+function M.has_next()
+  local ctx = get_ctx()
+
+  -- no completions at all
+  if not ctx.suggestions or #ctx.suggestions == 0 then
+    return false
+  end
+
+  return (ctx.choice < #ctx.suggestions or not ctx.cycling)
+end
+
 local function advance(count, ctx)
   if ctx ~= get_ctx() then
     return


### PR DESCRIPTION
The suggestion's next-function automatically starts again from the beginning after having reached the last completion. 

As there is no way to prevent this behaviour with the current interface or configuration, a `has_next()` method was added, returning false when there are no further suggestions.

This allows code like

```lua
if cop.has_next() then
  cop.next()
end
```

The cycling to be skipped without side-effects that direct modification of `next()` could have.

Use-case: show all copilot suggestions. When all were shown, then show the LSP completion menu