### PR TITLE
Fixes regression where node_command contained spaces

### DIFF
--- a/lua/copilot/lsp/nodejs.lua
+++ b/lua/copilot/lsp/nodejs.lua
@@ -13,8 +13,7 @@ local M = {
 ---@return nil|string node_version_error
 function M.get_node_version()
   if not M.node_version then
-    local version_cmd = vim.split(M.node_command, " ")
-    table.insert(version_cmd, "--version")
+    local version_cmd = { M.node_command, "--version" }
 
     local node_version_major = 0
     local node_version = ""


### PR DESCRIPTION
vim.split was causing the node_command passed in to fail if it contained any spaces

Tested locally seemed to work, let me know if anything isn't covered edge case wise

Should fix #538 