### PR TITLE
fix: Fixes splitting of copilot_node_command

### DIFF
--- a/lua/copilot/lsp/nodejs.lua
+++ b/lua/copilot/lsp/nodejs.lua
@@ -95,7 +95,7 @@ end
 
 ---@return table
 function M.get_execute_command()
-  local cmd = vim.split(M.node_command, " ")
+  local cmd = { M.node_command }
   table.insert(cmd, M.server_path or M.get_server_path())
   table.insert(cmd, "--stdio")
   return cmd


### PR DESCRIPTION
Fixes previous commit of splitting copilot_node_command 

Tested locally using
```
      copilot_node_command = vim.fn.expand("$FNM_DIR") .. "/node-versions/v22.13.0/installation/bin/node",
```