### PR TITLE
fix: replace `vim.lsp.stop_client()` with `Client:stop()`

### DIFF
--- a/lua/copilot/client/init.lua
+++ b/lua/copilot/client/init.lua
@@ -26,8 +26,9 @@ local M = {
 ---@param id integer
 local function store_client_id(id)
   if M.id and M.id ~= id then
-    if vim.lsp.get_client_by_id(M.id) then
-      vim.lsp.stop_client(M.id)
+    local client = vim.lsp.get_client_by_id(M.id)
+    if client then
+      client:stop()
     end
   end
 
@@ -240,8 +241,9 @@ function M.teardown()
     vim.api.nvim_clear_autocmds({ group = M.augroup })
   end
 
-  if M.id then
-    vim.lsp.stop_client(M.id)
+  local client = vim.lsp.get_client_by_id(M.id)
+  if client then
+    client:stop()
   end
 end
 


### PR DESCRIPTION
`vim.lsp.stop_client()` is being deprecated in 0.12 and replaced by `Client:stop()`. This fixes a deprecation warning that's currently emitted when doing `:Copilot disable`.