### PR TITLE
fix: race in should_attach

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Install the plugin with your preferred plugin manager.
 For example, with [packer.nvim](https://github.com/wbthomason/packer.nvim):
 
 ```lua
-use { "zbirenbaum/copilot.lua" 
+use { "zbirenbaum/copilot.lua"
   requires = {
     "copilotlsp-nvim/copilot-lsp", -- (optional) for NES functionality
   },
@@ -198,14 +198,14 @@ require('copilot').setup({
   root_dir = function()
     return vim.fs.dirname(vim.fs.find(".git", { upward = true })[1])
   end,
-  should_attach = function(_, _)
-    if not vim.bo.buflisted then
+  should_attach = function(buf_id, _)
+    if not vim.bo[buf_id].buflisted then
       logger.debug("not attaching, buffer is not 'buflisted'")
       return false
     end
 
-    if vim.bo.buftype ~= "" then
-      logger.debug("not attaching, buffer 'buftype' is " .. vim.bo.buftype)
+    if vim.bo[buf_id].buftype ~= "" then
+      logger.debug("not attaching, buffer 'buftype' is " .. vim.bo[buf_id].buftype)
       return false
     end
 

--- a/lua/copilot/config/should_attach.lua
+++ b/lua/copilot/config/should_attach.lua
@@ -4,14 +4,14 @@ local logger = require("copilot.logger")
 
 local should_attach = {
   ---@type ShouldAttachFunc
-  default = function(_, _)
-    if not vim.bo.buflisted then
+  default = function(buf_id, _)
+    if not vim.bo[buf_id].buflisted then
       logger.debug("not attaching, buffer is not 'buflisted'")
       return false
     end
 
-    if vim.bo.buftype ~= "" then
-      logger.debug("not attaching, buffer 'buftype' is " .. vim.bo.buftype)
+    if vim.bo[buf_id].buftype ~= "" then
+      logger.debug("not attaching, buffer 'buftype' is " .. vim.bo[buf_id].buftype)
       return false
     end
 


### PR DESCRIPTION
The `should_attach` is executed using `vim.schedule` (in `on_buf_enter`), so it must use provided `buf_id` to make sure it checks given buffer instead of current one.