### PR TITLE
fix(keymaps): preserve special insert keys in passthrough fallback

### DIFF
--- a/lua/copilot/keymaps/init.lua
+++ b/lua/copilot/keymaps/init.lua
@@ -119,10 +119,11 @@ function M.register_keymap_with_passthrough(mode, key, action, desc, bufnr)
     end
 
     logger.trace("No previous keymap to pass through for " .. keymap_key)
-    return vim.api.nvim_replace_termcodes(key, true, false, true)
+    return key
   end, {
     desc = desc,
     expr = true,
+    replace_keycodes = true,
     silent = true,
     buffer = bufnr,
   })

--- a/tests/test_keymaps.lua
+++ b/tests/test_keymaps.lua
@@ -88,4 +88,16 @@ T["keymaps()"]["passthrough Tab - return false inserts tab character"] = functio
   MiniTest.expect.equality(line, "hello\tworld")
 end
 
+T["keymaps()"]["passthrough Right - return false moves cursor right"] = function()
+  child.lua([[
+    require("copilot.keymaps").register_keymap_with_passthrough("i", "<Right>", function()
+      return false
+    end, "Passthrough Right", vim.api.nvim_get_current_buf())
+  ]])
+  child.type_keys("i", "abcd", "<Esc>", "0i", "<Right>", "X", "<Esc>")
+
+  local line = child.lua("return vim.api.nvim_get_current_line()")
+  MiniTest.expect.equality(line, "aXbcd")
+end
+
 return T


### PR DESCRIPTION
This fixes insert-mode fallbacks like `<Right>` being inserted as literal bytes.