### PR TITLE
fix: detect glibc using getconf instead of ldd

### DIFF
--- a/lua/copilot/lsp/installer.lua
+++ b/lua/copilot/lsp/installer.lua
@@ -634,21 +634,31 @@ function M.reset()
 end
 
 local function detect_libc()
+  local ok, process = pcall(vim.system, { "getconf", "GNU_LIBC_VERSION" }, { text = true })
+  if ok and process then
+    local result = process:wait()
+    if result.code == 0 then
+      local output = ((result.stdout or "") .. (result.stderr or "")):lower()
+
+      if output:find("glibc", 1, true) then
+        return "glibc"
+      end
+    end
+  end
+
   local ok, process = pcall(vim.system, { "ldd", "--version" }, { text = true })
-  if not ok or not process then
-    return nil
+  if ok and process then
+    local result = process:wait()
+    if result.code == 0 then
+      local output = ((result.stdout or "") .. (result.stderr or "")):lower()
+
+      if output:find("musl", 1, true) then
+        return "musl"
+      end
+    end
   end
-  local result = process:wait()
-  if result.code ~= 0 then
-    return nil
-  end
-  local output = ((result.stdout or "") .. (result.stderr or "")):lower()
-  if output:find("musl", 1, true) then
-    return "musl"
-  end
-  if output:find("glibc", 1, true) or output:find("gnu libc", 1, true) then
-    return "glibc"
-  end
+
+  return nil
 end
 
 ---@param server_type string

--- a/lua/copilot/lsp/installer.lua
+++ b/lua/copilot/lsp/installer.lua
@@ -646,7 +646,7 @@ local function detect_libc()
     end
   end
 
-  local ok, process = pcall(vim.system, { "ldd", "--version" }, { text = true })
+  ok, process = pcall(vim.system, { "ldd", "--version" }, { text = true })
   if ok and process then
     local result = process:wait()
     if result.code == 0 then
@@ -654,6 +654,9 @@ local function detect_libc()
 
       if output:find("musl", 1, true) then
         return "musl"
+      end
+      if output:find("glibc", 1, true) or output:find("gnu libc", 1, true) then
+        return "glibc"
       end
     end
   end

--- a/tests/stubs/installer.lua
+++ b/tests/stubs/installer.lua
@@ -43,6 +43,13 @@ function M.start()
   active_restore = restore
   ---@diagnostic disable-next-line: duplicate-set-field
   vim.system = function(command, options, callback)
+    if command[1] == "getconf" then
+      return {
+        wait = function()
+          return { code = 0, stdout = "glibc 2.39", stderr = "" }
+        end,
+      }
+    end
     if command[1] == "ldd" then
       return {
         wait = function()

--- a/tests/test_installer.lua
+++ b/tests/test_installer.lua
@@ -189,15 +189,16 @@ local function run_install(target, responses, completion, setup, sysname, absent
   return canonical_path(root), result
 end
 
-local function with_ldd_probe(stdout, stderr, code, fail, callback)
+local function with_system_probe(probes, callback)
   local original_system = vim.system
-  vim.system = function()
-    if fail then
-      error("ldd failed to start")
+  vim.system = function(command)
+    local probe = probes[command[1]] or {}
+    if probe.fail then
+      error(command[1] .. " failed to start")
     end
     return {
       wait = function()
-        return { stdout = stdout, stderr = stderr, code = code }
+        return { stdout = probe.stdout, stderr = probe.stderr, code = probe.code }
       end,
     }
   end
@@ -281,28 +282,54 @@ T["resolve_target maps platforms and libc probes"] = function()
     eq(target, case[4])
     eq(err, nil)
   end
-  with_ldd_probe("ldd (GNU libc) 2.39", "", 0, false, function()
+  with_system_probe({
+    getconf = { stdout = "glibc 2.39", stderr = "", code = 0 },
+  }, function()
     eq(installer.resolve_target("binary", { sysname = "Linux", machine = "x86_64" }), "linux-x64")
   end)
-  with_ldd_probe("musl libc", "", 0, false, function()
+
+  with_system_probe({
+    getconf = { stdout = "glibc 2.39", stderr = "", code = 1 },
+    ldd = { stdout = "musl libc", stderr = "", code = 0 },
+  }, function()
     local target, err = installer.resolve_target("binary", { sysname = "Linux", machine = "x86_64" })
     eq(target, nil)
     local error_message = assert(err)
     eq(error_message:find('server.type = "nodejs"', 1, true) ~= nil, true)
   end)
-  with_ldd_probe(nil, nil, nil, true, function()
+
+  with_system_probe({
+    getconf = { stdout = "", stderr = "", code = 1 },
+    ldd = { stdout = "musl libc", stderr = "", code = 0 },
+  }, function()
     local target, err = installer.resolve_target("binary", { sysname = "Linux", machine = "x86_64" })
     eq(target, nil)
     local error_message = assert(err)
     eq(error_message:find('server.type = "nodejs"', 1, true) ~= nil, true)
   end)
-  with_ldd_probe("ldd: error", "", 1, false, function()
+
+  with_system_probe({
+    getconf = { fail = true },
+    ldd = { stdout = "", stderr = "", code = 1 },
+  }, function()
     local target, err = installer.resolve_target("binary", { sysname = "Linux", machine = "x86_64" })
     eq(target, nil)
     local error_message = assert(err)
     eq(error_message:find('server.type = "nodejs"', 1, true) ~= nil, true)
   end)
-  with_ldd_probe("ldd version unavailable", "", 0, false, function()
+  with_system_probe({
+    getconf = { stdout = "", stderr = "getconf: Unrecognized variable", code = 2 },
+    ldd = { stdout = "ldd: error", stderr = "", code = 1 },
+  }, function()
+    local target, err = installer.resolve_target("binary", { sysname = "Linux", machine = "x86_64" })
+    eq(target, nil)
+    local error_message = assert(err)
+    eq(error_message:find('server.type = "nodejs"', 1, true) ~= nil, true)
+  end)
+  with_system_probe({
+    getconf = { stdout = "", stderr = "getconf: Unrecognized variable", code = 2 },
+    ldd = { stdout = "ldd version unavailable", stderr = "", code = 0 },
+  }, function()
     local target, err = installer.resolve_target("binary", { sysname = "Linux", machine = "x86_64" })
     eq(target, nil)
     local error_message = assert(err)

--- a/tests/test_installer.lua
+++ b/tests/test_installer.lua
@@ -337,6 +337,28 @@ T["resolve_target maps platforms and libc probes"] = function()
   end)
 end
 
+T["resolve_target falls back to glibc ldd when getconf is missing"] = function()
+  with_system_probe({
+    getconf = { fail = true },
+    ldd = { stdout = "ldd (GNU libc) 2.39", stderr = "", code = 0 },
+  }, function()
+    local target, err = installer.resolve_target("binary", { sysname = "Linux", machine = "x86_64" })
+    eq(target, "linux-x64")
+    eq(err, nil)
+  end)
+end
+
+T["resolve_target falls back to glibc ldd when getconf fails"] = function()
+  with_system_probe({
+    getconf = { stdout = "", stderr = "getconf: Unrecognized variable", code = 2 },
+    ldd = { stdout = "ldd (GLIBC) 2.39", stderr = "", code = 0 },
+  }, function()
+    local target, err = installer.resolve_target("binary", { sysname = "Linux", machine = "aarch64" })
+    eq(target, "linux-arm64")
+    eq(err, nil)
+  end)
+end
+
 T["get_entrypoint resolves a deterministic cache hit"] = function()
   local target = fixture_target()
   local root = new_cache(target)


### PR DESCRIPTION
This is output of glibc gentoo:

```
ldd --version  
ldd (Gentoo 2.43-r2 (patchset 3)) 2.43
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.
```

Better is:

```
getconf GNU_LIBC_VERSION
glibc 2.43
```